### PR TITLE
Support notebooks

### DIFF
--- a/jedi_language_server/jedi_utils.py
+++ b/jedi_language_server/jedi_utils.py
@@ -148,22 +148,26 @@ def lsp_range(name: Name) -> Optional[Range]:
     )
 
 
-def lsp_location(name: Name) -> Optional[Location]:
+def lsp_location(name: Name, uri: Optional[str] = None) -> Optional[Location]:
     """Get LSP location from Jedi definition."""
-    module_path = name.module_path
-    if module_path is None:
-        return None
+    if uri is None:
+        module_path = name.module_path
+        if module_path is None:
+            return None
+        uri = module_path.as_uri()
 
     lsp = lsp_range(name)
     if lsp is None:
         return None
 
-    return Location(uri=module_path.as_uri(), range=lsp)
+    return Location(uri=uri, range=lsp)
 
 
-def lsp_symbol_information(name: Name) -> Optional[SymbolInformation]:
+def lsp_symbol_information(
+    name: Name, uri: Optional[str] = None
+) -> Optional[SymbolInformation]:
     """Get LSP SymbolInformation from Jedi definition."""
-    location = lsp_location(name)
+    location = lsp_location(name, uri)
     if location is None:
         return None
 

--- a/jedi_language_server/notebook_utils.py
+++ b/jedi_language_server/notebook_utils.py
@@ -1,0 +1,211 @@
+"""Utility functions for handling notebook documents."""
+
+from collections import defaultdict
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Union,
+)
+
+import attrs
+from lsprotocol.types import (
+    AnnotatedTextEdit,
+    Location,
+    NotebookDocument,
+    OptionalVersionedTextDocumentIdentifier,
+    Position,
+    Range,
+    TextDocumentEdit,
+    TextEdit,
+)
+from pygls.workspace import TextDocument, Workspace
+
+
+def notebook_coordinate_mapper(
+    workspace: Workspace,
+    *,
+    notebook_uri: Optional[str] = None,
+    cell_uri: Optional[str] = None,
+) -> Optional["NotebookCoordinateMapper"]:
+    notebook_document = workspace.get_notebook_document(
+        notebook_uri=notebook_uri, cell_uri=cell_uri
+    )
+    if notebook_document is None:
+        return None
+    cells = [
+        workspace.text_documents[cell.document]
+        for cell in notebook_document.cells
+    ]
+    return NotebookCoordinateMapper(notebook_document, cells)
+
+
+class DocumentPosition(NamedTuple):
+    """A position in a document."""
+
+    uri: str
+    position: Position
+
+
+class DocumentTextEdit(NamedTuple):
+    """A text edit in a document."""
+
+    uri: str
+    text_edit: Union[TextEdit, AnnotatedTextEdit]
+
+
+class NotebookCoordinateMapper:
+    """Maps positions between individual notebook cells and the concatenated notebook document."""
+
+    def __init__(
+        self,
+        notebook_document: NotebookDocument,
+        cells: List[TextDocument],
+    ):
+        self._document = notebook_document
+        self._cells = cells
+
+        # Construct helper data structures.
+        self._cell_by_uri: Dict[str, TextDocument] = {}
+        self._cell_line_range_by_uri: Dict[str, range] = {}
+        start_line = 0
+        for index, cell in enumerate(self._cells):
+            end_line = start_line + len(cell.lines)
+
+            self._cell_by_uri[cell.uri] = cell
+            self._cell_line_range_by_uri[cell.uri] = range(
+                start_line, end_line
+            )
+
+            start_line = end_line
+
+    @property
+    def source(self) -> str:
+        """Concatenated notebook source."""
+        return "\n".join(cell.source for cell in self._cells)
+
+    def notebook_position(
+        self, cell_uri: str, cell_position: Position
+    ) -> Position:
+        """Convert a cell position to a concatenated notebook position."""
+        line = (
+            self._cell_line_range_by_uri[cell_uri].start + cell_position.line
+        )
+        return Position(line=line, character=cell_position.character)
+
+    def notebook_range(self, cell_uri: str, cell_range: Range) -> Range:
+        """Convert a cell range to a concatenated notebook range."""
+        start = self.notebook_position(cell_uri, cell_range.start)
+        end = self.notebook_position(cell_uri, cell_range.end)
+        return Range(start=start, end=end)
+
+    def cell_position(
+        self, notebook_position: Position
+    ) -> Optional[DocumentPosition]:
+        """Convert a concatenated notebook position to a cell position."""
+        for cell in self._cells:
+            line_range = self._cell_line_range_by_uri[cell.uri]
+            if notebook_position.line in line_range:
+                line = notebook_position.line - line_range.start
+                return DocumentPosition(
+                    uri=cell.uri,
+                    position=Position(
+                        line=line, character=notebook_position.character
+                    ),
+                )
+        return None
+
+    def cell_range(self, notebook_range: Range) -> Optional[Location]:
+        """Convert a concatenated notebook range to a cell range.
+
+        Returns a `Location` to identify the cell that the range is in.
+        """
+        start = self.cell_position(notebook_range.start)
+        if start is None:
+            return None
+
+        end = self.cell_position(notebook_range.end)
+        if end is None:
+            return None
+
+        if start.uri != end.uri:
+            return None
+
+        return Location(
+            uri=start.uri, range=Range(start=start.position, end=end.position)
+        )
+
+    def cell_location(self, notebook_location: Location) -> Optional[Location]:
+        """Convert a concatenated notebook location to a cell location."""
+        if notebook_location.uri != self._document.uri:
+            return None
+        return self.cell_range(notebook_location.range)
+
+    def cell_index(self, cell_uri: str) -> Optional[int]:
+        """Get the index of a cell by its URI."""
+        for index, cell in enumerate(self._cells):
+            if cell.uri == cell_uri:
+                return index
+        return None
+
+    def cell_text_edit(
+        self, text_edit: Union[TextEdit, AnnotatedTextEdit]
+    ) -> Optional[DocumentTextEdit]:
+        """Convert a concatenated notebook text edit to a cell text edit."""
+        location = self.cell_range(text_edit.range)
+        if location is None:
+            return None
+
+        return DocumentTextEdit(
+            uri=location.uri,
+            text_edit=attrs.evolve(text_edit, range=location.range),
+        )
+
+    def cell_text_document_edits(
+        self, text_document_edit: TextDocumentEdit
+    ) -> Iterable[TextDocumentEdit]:
+        """Convert a concatenated notebook text document edit to cell text document edits."""
+        if text_document_edit.text_document.uri != self._document.uri:
+            return
+
+        # Convert edits in the concatenated notebook to per-cell edits, grouped by cell URI.
+        edits_by_uri: Dict[str, List[Union[TextEdit, AnnotatedTextEdit]]] = (
+            defaultdict(list)
+        )
+        for text_edit in text_document_edit.edits:
+            cell_text_edit = self.cell_text_edit(text_edit)
+            if cell_text_edit is not None:
+                edits_by_uri[cell_text_edit.uri].append(
+                    cell_text_edit.text_edit
+                )
+
+        # Yield per-cell text document edits.
+        for uri, edits in edits_by_uri.items():
+            cell = self._cell_by_uri[uri]
+            version = 0 if cell.version is None else cell.version
+            yield TextDocumentEdit(
+                text_document=OptionalVersionedTextDocumentIdentifier(
+                    uri=cell.uri, version=version
+                ),
+                edits=edits,
+            )
+
+
+def text_document_or_cell_locations(
+    workspace: Workspace, locations: List[Location]
+) -> List[Location]:
+    """Convert concatenated notebook locations to cell locations, leaving text document locations as-is."""
+    results = []
+    for location in locations:
+        mapper = notebook_coordinate_mapper(
+            workspace, notebook_uri=location.uri
+        )
+        if mapper is not None:
+            cell_location = mapper.cell_location(location)
+            if cell_location is not None:
+                location = cell_location
+
+        results.append(location)
+    return results

--- a/tests/lsp_tests/test_completion.py
+++ b/tests/lsp_tests/test_completion.py
@@ -195,3 +195,62 @@ def test_lsp_completion_class_noargs() -> None:
             ],
         }
         assert_that(actual, is_(expected))
+
+
+def test_lsp_completion_notebook() -> None:
+    """Test a simple completion request, in a notebook.
+
+    Test Data: tests/test_data/completion/completion_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+
+        path = COMPLETION_TEST_ROOT / "completion_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+        actual = ls_session.text_document_completion(
+            {
+                "textDocument": {"uri": cell_uris[1]},
+                "position": {"line": 0, "character": 2},
+                "context": {"triggerKind": 1},
+            }
+        )
+
+        expected = {
+            "isIncomplete": False,
+            "items": [
+                {
+                    "label": "my_function",
+                    "kind": 3,
+                    "sortText": "v0",
+                    "filterText": "my_function",
+                    "insertText": "my_function()$0",
+                    "insertTextFormat": 2,
+                }
+            ],
+        }
+        assert_that(actual, is_(expected))
+
+        actual = ls_session.completion_item_resolve(
+            {
+                "label": "my_function",
+                "kind": 3,
+                "sortText": "v0",
+                "filterText": "my_function",
+                "insertText": "my_function()$0",
+                "insertTextFormat": 2,
+            }
+        )
+        expected = {
+            "label": "my_function",
+            "kind": 3,
+            "detail": "def my_function()",
+            "documentation": {
+                "kind": "markdown",
+                "value": "Simple test function.",
+            },
+            "sortText": "v0",
+            "filterText": "my_function",
+            "insertText": "my_function()$0",
+            "insertTextFormat": 2,
+        }
+        assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_definition.py
+++ b/tests/lsp_tests/test_definition.py
@@ -38,6 +38,36 @@ def test_definition():
         assert_that(actual, is_(expected))
 
 
+def test_definition_notebook():
+    """Tests definition on a function imported from a module, in a notebook.
+
+    Test Data: tests/test_data/definition/definition_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = DEFINITION_TEST_ROOT / "definition_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+        actual = ls_session.text_document_definition(
+            {
+                "textDocument": {"uri": cell_uris[1]},
+                "position": {"line": 1, "character": 20},
+            }
+        )
+
+        module_uri = as_uri(DEFINITION_TEST_ROOT / "somemodule2.py")
+        expected = [
+            {
+                "uri": module_uri,
+                "range": {
+                    "start": {"line": 3, "character": 4},
+                    "end": {"line": 3, "character": 17},
+                },
+            }
+        ]
+
+        assert_that(actual, is_(expected))
+
+
 def test_declaration():
     """Tests declaration on an imported module.
 
@@ -59,6 +89,35 @@ def test_declaration():
                 "range": {
                     "start": {"line": 2, "character": 26},
                     "end": {"line": 2, "character": 37},
+                },
+            }
+        ]
+
+        assert_that(actual, is_(expected))
+
+
+def test_declaration_notebook():
+    """Tests declaration on an imported module, in a notebook.
+
+    Test Data: tests/test_data/definition/definition_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = DEFINITION_TEST_ROOT / "definition_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+        actual = ls_session.text_document_declaration(
+            {
+                "textDocument": {"uri": cell_uris[1]},
+                "position": {"line": 0, "character": 0},
+            }
+        )
+
+        expected = [
+            {
+                "uri": cell_uris[0],
+                "range": {
+                    "start": {"line": 0, "character": 7},
+                    "end": {"line": 0, "character": 17},
                 },
             }
         ]

--- a/tests/lsp_tests/test_document_symbol.py
+++ b/tests/lsp_tests/test_document_symbol.py
@@ -171,6 +171,194 @@ def test_document_symbol() -> None:
         assert_that(actual, is_(expected))
 
 
+def test_document_symbol_notebook() -> None:
+    """Test document symbol request for notebooks.
+
+    Test Data: tests/test_data/symbol/symbol_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = SYMBOL_TEST_ROOT / "symbol_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[0]}}
+        )
+
+        expected = [
+            {
+                "name": "Any",
+                "kind": 5,
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 22},
+                },
+                "selectionRange": {
+                    "start": {"line": 0, "character": 19},
+                    "end": {"line": 0, "character": 22},
+                },
+                "detail": "class Any",
+                "children": [],
+            },
+            {
+                "name": "somemodule",
+                "kind": 2,
+                "range": {
+                    "start": {"line": 2, "character": 0},
+                    "end": {"line": 2, "character": 37},
+                },
+                "selectionRange": {
+                    "start": {"line": 2, "character": 14},
+                    "end": {"line": 2, "character": 24},
+                },
+                "detail": "module somemodule",
+                "children": [],
+            },
+            {
+                "name": "somemodule2",
+                "kind": 2,
+                "range": {
+                    "start": {"line": 2, "character": 0},
+                    "end": {"line": 2, "character": 37},
+                },
+                "selectionRange": {
+                    "start": {"line": 2, "character": 26},
+                    "end": {"line": 2, "character": 37},
+                },
+                "detail": "module somemodule2",
+                "children": [],
+            },
+        ]
+
+        assert_that(actual, is_(expected))
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[1]}}
+        )
+
+        expected = [
+            {
+                "name": "SOME_CONSTANT",
+                "kind": 13,
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 17},
+                },
+                "selectionRange": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 0, "character": 13},
+                },
+                "detail": "SOME_CONSTANT = 1",
+                "children": [],
+            },
+        ]
+
+        assert_that(actual, is_(expected))
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[2]}}
+        )
+
+        expected = [
+            {
+                "name": "do_work",
+                "kind": 12,
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 3, "character": 35},
+                },
+                "selectionRange": {
+                    "start": {"line": 0, "character": 4},
+                    "end": {"line": 0, "character": 11},
+                },
+                "detail": "def do_work",
+                "children": [],
+            },
+        ]
+
+        assert_that(actual, is_(expected))
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[3]}}
+        )
+
+        expected = [
+            {
+                "name": "SomeClass",
+                "kind": 5,
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 10, "character": 38},
+                },
+                "selectionRange": {
+                    "start": {"line": 0, "character": 6},
+                    "end": {"line": 0, "character": 15},
+                },
+                "detail": "class SomeClass",
+                "children": [
+                    {
+                        "name": "__init__",
+                        "kind": 6,
+                        "range": {
+                            "start": {"line": 3, "character": 4},
+                            "end": {"line": 4, "character": 28},
+                        },
+                        "selectionRange": {
+                            "start": {"line": 3, "character": 8},
+                            "end": {"line": 3, "character": 16},
+                        },
+                        "detail": "def __init__",
+                        "children": [],
+                    },
+                    {
+                        "name": "somedata",
+                        "kind": 7,
+                        "range": {
+                            "start": {"line": 4, "character": 8},
+                            "end": {"line": 4, "character": 28},
+                        },
+                        "selectionRange": {
+                            "start": {"line": 4, "character": 13},
+                            "end": {"line": 4, "character": 21},
+                        },
+                        "detail": "self.somedata = arg1",
+                        "children": [],
+                    },
+                    {
+                        "name": "do_something",
+                        "kind": 6,
+                        "range": {
+                            "start": {"line": 6, "character": 4},
+                            "end": {"line": 7, "character": 38},
+                        },
+                        "selectionRange": {
+                            "start": {"line": 6, "character": 8},
+                            "end": {"line": 6, "character": 20},
+                        },
+                        "detail": "def do_something",
+                        "children": [],
+                    },
+                    {
+                        "name": "so_something_else",
+                        "kind": 6,
+                        "range": {
+                            "start": {"line": 9, "character": 4},
+                            "end": {"line": 10, "character": 38},
+                        },
+                        "selectionRange": {
+                            "start": {"line": 9, "character": 8},
+                            "end": {"line": 9, "character": 25},
+                        },
+                        "detail": "def so_something_else",
+                        "children": [],
+                    },
+                ],
+            },
+        ]
+
+        assert_that(actual, is_(expected))
+
+
 def test_document_symbol_no_hierarchy() -> None:
     """Test document symbol request with hierarchy turned off.
 
@@ -307,6 +495,176 @@ def test_document_symbol_no_hierarchy() -> None:
                     },
                 },
                 "containerName": "tests.test_data.symbol.symbol_test1.SomeClass.so_something_else",
+            },
+        ]
+        assert_that(actual, is_(expected))
+
+
+def test_document_symbol_no_hierarchy_notebook() -> None:
+    """Test document symbol request with hierarchy turned off for notebooks.
+
+    Test Data: tests/test_data/symbol/symbol_test1.ipynb
+    """
+    initialize_params = copy.deepcopy(VSCODE_DEFAULT_INITIALIZE)
+    initialize_params["capabilities"]["textDocument"]["documentSymbol"][
+        "hierarchicalDocumentSymbolSupport"
+    ] = False
+    with session.LspSession() as ls_session:
+        ls_session.initialize(initialize_params)
+        path = SYMBOL_TEST_ROOT / "symbol_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[0]}}
+        )
+
+        expected = [
+            {
+                "name": "Any",
+                "kind": 5,
+                "location": {
+                    "uri": cell_uris[0],
+                    "range": {
+                        "start": {"line": 0, "character": 19},
+                        "end": {"line": 0, "character": 22},
+                    },
+                },
+                "containerName": "typing.Any",
+            },
+            {
+                "name": "somemodule",
+                "kind": 2,
+                "location": {
+                    "uri": cell_uris[0],
+                    "range": {
+                        "start": {"line": 2, "character": 14},
+                        "end": {"line": 2, "character": 24},
+                    },
+                },
+                "containerName": "somemodule",
+            },
+            {
+                "name": "somemodule2",
+                "kind": 2,
+                "location": {
+                    "uri": cell_uris[0],
+                    "range": {
+                        "start": {"line": 2, "character": 26},
+                        "end": {"line": 2, "character": 37},
+                    },
+                },
+                "containerName": "somemodule2",
+            },
+        ]
+
+        assert_that(actual, is_(expected))
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[1]}}
+        )
+
+        expected = [
+            {
+                "name": "SOME_CONSTANT",
+                "kind": 13,
+                "location": {
+                    "uri": cell_uris[1],
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 13},
+                    },
+                },
+                "containerName": "tests.test_data.symbol.symbol_test1.ipynb.SOME_CONSTANT",
+            },
+        ]
+
+        assert_that(actual, is_(expected))
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[2]}}
+        )
+
+        expected = [
+            {
+                "name": "do_work",
+                "kind": 12,
+                "location": {
+                    "uri": cell_uris[2],
+                    "range": {
+                        "start": {"line": 0, "character": 4},
+                        "end": {"line": 0, "character": 11},
+                    },
+                },
+                "containerName": "tests.test_data.symbol.symbol_test1.ipynb.do_work",
+            },
+        ]
+
+        assert_that(actual, is_(expected))
+
+        actual = ls_session.text_document_symbol(
+            {"textDocument": {"uri": cell_uris[3]}}
+        )
+
+        expected = [
+            {
+                "name": "SomeClass",
+                "kind": 5,
+                "location": {
+                    "uri": cell_uris[3],
+                    "range": {
+                        "start": {"line": 0, "character": 6},
+                        "end": {"line": 0, "character": 15},
+                    },
+                },
+                "containerName": "tests.test_data.symbol.symbol_test1.ipynb.SomeClass",
+            },
+            {
+                "name": "__init__",
+                "kind": 12,
+                "location": {
+                    "uri": cell_uris[3],
+                    "range": {
+                        "start": {"line": 3, "character": 8},
+                        "end": {"line": 3, "character": 16},
+                    },
+                },
+                "containerName": "tests.test_data.symbol.symbol_test1.ipynb.SomeClass.__init__",
+            },
+            {
+                "name": "somedata",
+                "kind": 13,
+                "location": {
+                    "uri": cell_uris[3],
+                    "range": {
+                        "start": {"line": 4, "character": 13},
+                        "end": {"line": 4, "character": 21},
+                    },
+                },
+                "containerName": "tests.test_data.symbol.symbol_test1.ipynb.SomeClass.__init__.somedata",
+            },
+            {
+                "name": "do_something",
+                "kind": 12,
+                "location": {
+                    "uri": cell_uris[3],
+                    "range": {
+                        "start": {"line": 6, "character": 8},
+                        "end": {"line": 6, "character": 20},
+                    },
+                },
+                "containerName": "tests.test_data.symbol.symbol_test1.ipynb.SomeClass.do_something",
+            },
+            {
+                "name": "so_something_else",
+                "kind": 12,
+                "location": {
+                    "uri": cell_uris[3],
+                    "range": {
+                        "start": {"line": 9, "character": 8},
+                        "end": {"line": 9, "character": 25},
+                    },
+                },
+                "containerName": "tests.test_data.symbol.symbol_test1.ipynb.SomeClass.so_something_else",
             },
         ]
         assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_highlighting.py
+++ b/tests/lsp_tests/test_highlighting.py
@@ -233,3 +233,254 @@ def test_highlighting(position, expected):
         )
 
         assert_that(actual, is_(expected))
+
+
+@pytest.mark.parametrize(
+    ["cell", "position", "expected"],
+    [
+        (0, {"line": 2, "character": 3}, None),
+        (
+            0,
+            {"line": 2, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 2, "character": 5},
+                        "end": {"line": 2, "character": 9},
+                    }
+                }
+            ],
+        ),
+        (
+            0,
+            {"line": 2, "character": 20},
+            [
+                {
+                    "range": {
+                        "start": {"line": 2, "character": 17},
+                        "end": {"line": 2, "character": 21},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 12, "character": 16},
+                        "end": {"line": 12, "character": 20},
+                    }
+                },
+            ],
+        ),
+        (
+            0,
+            {"line": 4, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 4, "character": 0},
+                        "end": {"line": 4, "character": 13},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 20, "character": 15},
+                        "end": {"line": 20, "character": 28},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 24, "character": 29},
+                        "end": {"line": 24, "character": 42},
+                    }
+                },
+            ],
+        ),
+        (
+            0,
+            {"line": 7, "character": 9},
+            [
+                {
+                    "range": {
+                        "start": {"line": 7, "character": 4},
+                        "end": {"line": 7, "character": 17},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 24, "character": 15},
+                        "end": {"line": 24, "character": 28},
+                    }
+                },
+            ],
+        ),
+        (
+            0,
+            {"line": 7, "character": 20},
+            [
+                {
+                    "range": {
+                        "start": {"line": 7, "character": 18},
+                        "end": {"line": 7, "character": 21},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 9, "character": 11},
+                        "end": {"line": 9, "character": 14},
+                    }
+                },
+            ],
+        ),
+        (
+            0,
+            {"line": 12, "character": 14},
+            [
+                {
+                    "range": {
+                        "start": {"line": 12, "character": 6},
+                        "end": {"line": 12, "character": 15},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 27, "character": 11},
+                        "end": {"line": 27, "character": 20},
+                    }
+                },
+            ],
+        ),
+        (
+            0,
+            {"line": 15, "character": 20},
+            [
+                {
+                    "range": {
+                        "start": {"line": 15, "character": 17},
+                        "end": {"line": 15, "character": 21},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 16, "character": 8},
+                        "end": {"line": 16, "character": 12},
+                    }
+                },
+            ],
+        ),
+        (
+            0,
+            {"line": 16, "character": 17},
+            [
+                {
+                    "range": {
+                        "start": {"line": 16, "character": 13},
+                        "end": {"line": 16, "character": 19},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 20, "character": 36},
+                        "end": {"line": 20, "character": 42},
+                    }
+                },
+            ],
+        ),
+        (
+            0,
+            {"line": 18, "character": 15},
+            [
+                {
+                    "range": {
+                        "start": {"line": 18, "character": 8},
+                        "end": {"line": 18, "character": 20},
+                    }
+                },
+                {
+                    "range": {
+                        "start": {"line": 28, "character": 9},
+                        "end": {"line": 28, "character": 21},
+                    }
+                },
+            ],
+        ),
+        # __file__
+        (
+            0,
+            {"line": 34, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 34, "character": 6},
+                        "end": {"line": 34, "character": 14},
+                    }
+                },
+            ],
+        ),
+        # __package__
+        (
+            0,
+            {"line": 35, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 35, "character": 6},
+                        "end": {"line": 35, "character": 17},
+                    }
+                },
+            ],
+        ),
+        # __doc__
+        (
+            0,
+            {"line": 36, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 36, "character": 6},
+                        "end": {"line": 36, "character": 13},
+                    }
+                },
+            ],
+        ),
+        # __name__
+        (
+            0,
+            {"line": 37, "character": 8},
+            [
+                {
+                    "range": {
+                        "start": {"line": 37, "character": 6},
+                        "end": {"line": 37, "character": 14},
+                    }
+                },
+            ],
+        ),
+        (
+            1,
+            {"line": 0, "character": 0},
+            [
+                {
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 13},
+                    }
+                }
+            ],
+        ),
+    ],
+)
+def test_highlighting_notebook(cell, position, expected):
+    """Tests highlighting on import statement for notebooks.
+
+    Test Data: tests/test_data/highlighting/highlighting_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = HIGHLIGHTING_TEST_ROOT / "highlighting_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+        actual = ls_session.text_document_highlight(
+            {
+                "textDocument": {"uri": cell_uris[cell]},
+                "position": position,
+            }
+        )
+
+        assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_hover.py
+++ b/tests/lsp_tests/test_hover.py
@@ -37,6 +37,36 @@ def test_hover_on_module():
         assert_that(actual, is_(expected))
 
 
+def test_hover_on_module_notebook():
+    """Tests hover on the name of an imported module in a notebook.
+
+    Test Data: tests/test_data/hover/hover_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = HOVER_TEST_ROOT / "hover_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+
+        actual = ls_session.text_document_hover(
+            {
+                "textDocument": {"uri": cell_uris[0]},
+                "position": {"line": 0, "character": 12},
+            }
+        )
+
+        expected = {
+            "contents": {
+                "kind": "markdown",
+                "value": "```python\nmodule somemodule\n```\n---\nModule doc string for testing.",
+            },
+            "range": {
+                "start": {"line": 0, "character": 7},
+                "end": {"line": 0, "character": 17},
+            },
+        }
+        assert_that(actual, is_(expected))
+
+
 def test_hover_on_function():
     """Tests hover on the name of a function.
 
@@ -60,6 +90,36 @@ def test_hover_on_function():
             "range": {
                 "start": {"line": 4, "character": 11},
                 "end": {"line": 4, "character": 23},
+            },
+        }
+        assert_that(actual, is_(expected))
+
+
+def test_hover_on_function_notebook():
+    """Tests hover on the name of a function in a notebook.
+
+    Test Data: tests/test_data/hover/hover_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = HOVER_TEST_ROOT / "hover_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+
+        actual = ls_session.text_document_hover(
+            {
+                "textDocument": {"uri": cell_uris[1]},
+                "position": {"line": 0, "character": 19},
+            }
+        )
+
+        expected = {
+            "contents": {
+                "kind": "markdown",
+                "value": "```python\ndef do_something()\n```\n---\nFunction doc string for testing.\n**Full name:** `somemodule.do_something`",
+            },
+            "range": {
+                "start": {"line": 0, "character": 11},
+                "end": {"line": 0, "character": 23},
             },
         }
         assert_that(actual, is_(expected))
@@ -93,6 +153,36 @@ def test_hover_on_class():
         assert_that(actual, is_(expected))
 
 
+def test_hover_on_class_notebook():
+    """Tests hover on the name of a class in a notebook.
+
+    Test Data: tests/test_data/hover/hover_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = HOVER_TEST_ROOT / "hover_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+
+        actual = ls_session.text_document_hover(
+            {
+                "textDocument": {"uri": cell_uris[2]},
+                "position": {"line": 0, "character": 21},
+            }
+        )
+
+        expected = {
+            "contents": {
+                "kind": "markdown",
+                "value": "```python\nclass SomeClass()\n```\n---\nClass doc string for testing.\n**Full name:** `somemodule.SomeClass`",
+            },
+            "range": {
+                "start": {"line": 0, "character": 15},
+                "end": {"line": 0, "character": 24},
+            },
+        }
+        assert_that(actual, is_(expected))
+
+
 def test_hover_on_method():
     """Tests hover on the name of a class method.
 
@@ -121,6 +211,36 @@ def test_hover_on_method():
         assert_that(actual, is_(expected))
 
 
+def test_hover_on_method_notebook():
+    """Tests hover on the name of a class method in a notebook.
+
+    Test Data: tests/test_data/hover/hover_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = HOVER_TEST_ROOT / "hover_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+
+        actual = ls_session.text_document_hover(
+            {
+                "textDocument": {"uri": cell_uris[3]},
+                "position": {"line": 0, "character": 6},
+            }
+        )
+
+        expected = {
+            "contents": {
+                "kind": "markdown",
+                "value": "```python\ndef some_method()\n```\n---\nMethod doc string for testing.\n**Full name:** `somemodule.SomeClass.some_method`",
+            },
+            "range": {
+                "start": {"line": 0, "character": 2},
+                "end": {"line": 0, "character": 13},
+            },
+        }
+        assert_that(actual, is_(expected))
+
+
 def test_hover_on_method_no_docstring():
     """Tests hover on the name of a class method without doc string.
 
@@ -144,6 +264,36 @@ def test_hover_on_method_no_docstring():
             "range": {
                 "start": {"line": 10, "character": 2},
                 "end": {"line": 10, "character": 14},
+            },
+        }
+        assert_that(actual, is_(expected))
+
+
+def test_hover_on_method_no_docstring_notebook():
+    """Tests hover on the name of a class method without doc string in a notebook.
+
+    Test Data: tests/test_data/hover/hover_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = HOVER_TEST_ROOT / "hover_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+
+        actual = ls_session.text_document_hover(
+            {
+                "textDocument": {"uri": cell_uris[4]},
+                "position": {"line": 0, "character": 6},
+            }
+        )
+
+        expected = {
+            "contents": {
+                "kind": "markdown",
+                "value": "```python\ndef some_method2()\n```\n---\n**Full name:** `somemodule.SomeClass.some_method2`",
+            },
+            "range": {
+                "start": {"line": 0, "character": 2},
+                "end": {"line": 0, "character": 14},
             },
         }
         assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_references.py
+++ b/tests/lsp_tests/test_references.py
@@ -19,7 +19,9 @@ references1 = as_uri(REFERENCES_TEST_ROOT / "references_test1.py")
 @pytest.mark.parametrize(
     ["position", "expected"],
     [
+        # from
         ({"line": 2, "character": 3}, None),
+        # SOME_CONSTANT
         (
             {"line": 4, "character": 8},
             [
@@ -46,6 +48,7 @@ references1 = as_uri(REFERENCES_TEST_ROOT / "references_test1.py")
                 },
             ],
         ),
+        # some_function
         (
             {"line": 7, "character": 9},
             [
@@ -65,6 +68,7 @@ references1 = as_uri(REFERENCES_TEST_ROOT / "references_test1.py")
                 },
             ],
         ),
+        # arg of some_function
         (
             {"line": 7, "character": 20},
             [
@@ -84,6 +88,7 @@ references1 = as_uri(REFERENCES_TEST_ROOT / "references_test1.py")
                 },
             ],
         ),
+        # SomeClass
         (
             {"line": 12, "character": 14},
             [
@@ -103,6 +108,7 @@ references1 = as_uri(REFERENCES_TEST_ROOT / "references_test1.py")
                 },
             ],
         ),
+        # self arg of SomeClass.__init__
         (
             {"line": 15, "character": 20},
             [
@@ -122,6 +128,7 @@ references1 = as_uri(REFERENCES_TEST_ROOT / "references_test1.py")
                 },
             ],
         ),
+        # SomeClass._field
         (
             {"line": 16, "character": 17},
             [
@@ -141,6 +148,7 @@ references1 = as_uri(REFERENCES_TEST_ROOT / "references_test1.py")
                 },
             ],
         ),
+        # SomeClass.some_method1
         (
             {"line": 18, "character": 15},
             [
@@ -187,4 +195,190 @@ def test_references(position, expected):
             }
         )
 
+        assert_that(actual, is_(expected))
+
+
+@pytest.mark.parametrize(
+    ["cell", "position", "expected"],
+    [
+        # from
+        (0, {"line": 0, "character": 3}, None),
+        # SOME_CONSTANT
+        (
+            1,
+            {"line": 0, "character": 8},
+            [
+                {
+                    "cell": 1,
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 13},
+                    },
+                },
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 8, "character": 15},
+                        "end": {"line": 8, "character": 28},
+                    },
+                },
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 12, "character": 29},
+                        "end": {"line": 12, "character": 42},
+                    },
+                },
+            ],
+        ),
+        # some_function
+        (
+            2,
+            {"line": 0, "character": 9},
+            [
+                {
+                    "cell": 2,
+                    "range": {
+                        "start": {"line": 0, "character": 4},
+                        "end": {"line": 0, "character": 17},
+                    },
+                },
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 12, "character": 15},
+                        "end": {"line": 12, "character": 28},
+                    },
+                },
+            ],
+        ),
+        # arg of some_function
+        (
+            2,
+            {"line": 0, "character": 20},
+            [
+                {
+                    "cell": 2,
+                    "range": {
+                        "start": {"line": 0, "character": 18},
+                        "end": {"line": 0, "character": 21},
+                    },
+                },
+                {
+                    "cell": 2,
+                    "range": {
+                        "start": {"line": 2, "character": 11},
+                        "end": {"line": 2, "character": 14},
+                    },
+                },
+            ],
+        ),
+        # SomeClass
+        (
+            3,
+            {"line": 0, "character": 14},
+            [
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 0, "character": 6},
+                        "end": {"line": 0, "character": 15},
+                    },
+                },
+                {
+                    "cell": 4,
+                    "range": {
+                        "start": {"line": 0, "character": 11},
+                        "end": {"line": 0, "character": 20},
+                    },
+                },
+            ],
+        ),
+        # self arg of SomeClass.__init__
+        (
+            3,
+            {"line": 3, "character": 20},
+            [
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 3, "character": 17},
+                        "end": {"line": 3, "character": 21},
+                    },
+                },
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 4, "character": 8},
+                        "end": {"line": 4, "character": 12},
+                    },
+                },
+            ],
+        ),
+        # SomeClass._field
+        (
+            3,
+            {"line": 4, "character": 17},
+            [
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 4, "character": 13},
+                        "end": {"line": 4, "character": 19},
+                    },
+                },
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 8, "character": 36},
+                        "end": {"line": 8, "character": 42},
+                    },
+                },
+            ],
+        ),
+        # SomeClass.some_method1
+        (
+            3,
+            {"line": 6, "character": 15},
+            [
+                {
+                    "cell": 3,
+                    "range": {
+                        "start": {"line": 6, "character": 8},
+                        "end": {"line": 6, "character": 20},
+                    },
+                },
+                {
+                    "cell": 4,
+                    "range": {
+                        "start": {"line": 1, "character": 9},
+                        "end": {"line": 1, "character": 21},
+                    },
+                },
+            ],
+        ),
+    ],
+)
+def test_references_notebook(cell, position, expected):
+    """Tests references in a notebook.
+
+    Test Data: tests/test_data/references/references_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = REFERENCES_TEST_ROOT / "references_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+        actual = ls_session.text_document_references(
+            {
+                "textDocument": {"uri": cell_uris[cell]},
+                "position": position,
+                "context": {
+                    "includeDeclaration": True,
+                },
+            }
+        )
+
+        if expected:
+            for item in expected:
+                item["uri"] = cell_uris[item.pop("cell")]
         assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_signature.py
+++ b/tests/lsp_tests/test_signature.py
@@ -55,3 +55,51 @@ def test_signature_help(trigger_char, column, active_param):
         }
 
         assert_that(actual, is_(expected))
+
+
+@pytest.mark.parametrize(
+    ["trigger_char", "column", "active_param"], [("(", 14, 0), (",", 18, 1)]
+)
+def test_signature_help_notebook(trigger_char, column, active_param):
+    """Tests signature help response for a function in a notebook.
+
+    Test Data: tests/test_data/signature/signature_test1.ipynb
+    """
+    with session.LspSession() as ls_session:
+        ls_session.initialize()
+        path = SIGNATURE_TEST_ROOT / "signature_test1.ipynb"
+        cell_uris = ls_session.open_notebook_document(path)
+        actual = ls_session.text_document_signature_help(
+            {
+                "textDocument": {"uri": cell_uris[1]},
+                "position": {"line": 0, "character": column},
+                "context": {
+                    "isRetrigger": False,
+                    "triggerCharacter": trigger_char,
+                    "triggerKind": 2,
+                },
+            }
+        )
+
+        expected = {
+            "signatures": [
+                {
+                    "label": (
+                        "def some_function(arg1: str, arg2: int, arg3: list)"
+                    ),
+                    "documentation": {
+                        "kind": "markdown",
+                        "value": "This is a test function.",
+                    },
+                    "parameters": [
+                        {"label": "arg1: str"},
+                        {"label": "arg2: int"},
+                        {"label": "arg3: list"},
+                    ],
+                }
+            ],
+            "activeSignature": 0,
+            "activeParameter": active_param,
+        }
+
+        assert_that(actual, is_(expected))

--- a/tests/lsp_tests/test_workspace_symbol.py
+++ b/tests/lsp_tests/test_workspace_symbol.py
@@ -10,9 +10,9 @@ SYMBOL_TEST_ROOT = TEST_DATA / "symbol"
 
 
 def test_workspace_symbol() -> None:
-    """Test document symbol request.
+    """Test workspace symbol request.
 
-    Test Data: tests/test_data/symbol/symbol_test1.py
+    Test Data: tests/test_data/symbol/somemodule2.py
     """
     with session.LspSession() as ls_session:
         ls_session.initialize()

--- a/tests/test_data/completion/completion_test1.ipynb
+++ b/tests/test_data/completion/completion_test1.ipynb
@@ -1,0 +1,31 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def my_function():\n",
+    "    \"\"\"Simple test function.\"\"\"\n",
+    "    return 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/definition/definition_test1.ipynb
+++ b/tests/test_data/definition/definition_test1.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import somemodule, somemodule2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "somemodule.some_function()\n",
+    "somemodule2.some_function()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/definition/definition_test2.ipynb
+++ b/tests/test_data/definition/definition_test2.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def some_function():\n",
+    "    \"\"\"Some test function.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "some_function()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/highlighting/highlighting_test1.ipynb
+++ b/tests/test_data/highlighting/highlighting_test1.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Test file for highlighting.\"\"\"\n",
+    "\n",
+    "from enum import Enum\n",
+    "\n",
+    "SOME_CONSTANT = \"something\"\n",
+    "\n",
+    "\n",
+    "def some_function(arg: str) -> str:\n",
+    "    \"\"\"Test function for highlighting.\"\"\"\n",
+    "    return arg\n",
+    "\n",
+    "\n",
+    "class SomeClass(Enum):\n",
+    "    \"\"\"Test class for highlighting.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self._field = 1\n",
+    "\n",
+    "    def some_method1(self):\n",
+    "        \"\"\"Test method for highlighting.\"\"\"\n",
+    "        return SOME_CONSTANT + self._field\n",
+    "\n",
+    "    def some_method2(self):\n",
+    "        \"\"\"Test method for highlighting.\"\"\"\n",
+    "        return some_function(SOME_CONSTANT)\n",
+    "\n",
+    "\n",
+    "instance = SomeClass()\n",
+    "instance.some_method1()\n",
+    "instance.some_method2()\n",
+    "\n",
+    "# Jedi returns an implicit definition for these special variables,\n",
+    "# which has no line number.  Highlighting of usages with line numbers\n",
+    "# should still function.\n",
+    "print(__file__)\n",
+    "print(__package__)\n",
+    "print(__doc__)\n",
+    "print(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOME_CONSTANT"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/hover/hover_test1.ipynb
+++ b/tests/test_data/hover/hover_test1.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import somemodule"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "somemodule.do_something()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = somemodule.SomeClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.some_method()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c.some_method2()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/refactoring/code_action_test1.ipynb
+++ b/tests/test_data/refactoring/code_action_test1.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Test file for code action tests in test_refactoring.\"\"\"\n",
+    "\n",
+    "\n",
+    "def do_something(x):\n",
+    "    if x == 1:\n",
+    "        pass"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/refactoring/rename_package_test1/rename_test_main.ipynb
+++ b/tests/test_data/refactoring/rename_package_test1/rename_test_main.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from old_name.some_module import do_something"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "do_something()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/refactoring/rename_test1.ipynb
+++ b/tests/test_data/refactoring/rename_test1.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def myfunc1():\n",
+    "    print(\"myfunc1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def my_function_2():\n",
+    "    myfunc1()\n",
+    "    print(\"my_function_2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "myfunc1()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_function_2()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/references/references_test1.ipynb
+++ b/tests/test_data/references/references_test1.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from enum import Enum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOME_CONSTANT = \"something\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def some_function(arg: str) -> str:\n",
+    "    \"\"\"Test function for references.\"\"\"\n",
+    "    return arg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SomeClass(Enum):\n",
+    "    \"\"\"Test class for references.\"\"\"\n",
+    "\n",
+    "    def __init__(self):\n",
+    "        self._field = 1\n",
+    "\n",
+    "    def some_method1(self):\n",
+    "        \"\"\"Test method for references.\"\"\"\n",
+    "        return SOME_CONSTANT + self._field\n",
+    "\n",
+    "    def some_method2(self):\n",
+    "        \"\"\"Test method for references.\"\"\"\n",
+    "        return some_function(SOME_CONSTANT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instance = SomeClass()\n",
+    "instance.some_method1()\n",
+    "instance.some_method2()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "jedi-language-server",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/signature/signature_test1.ipynb
+++ b/tests/test_data/signature/signature_test1.ipynb
@@ -1,0 +1,30 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def some_function(arg1: str, arg2: int, arg3: list):\n",
+    "    \"\"\"This is a test function.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "some_function(\"a\", 1, [])"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_data/symbol/symbol_test1.ipynb
+++ b/tests/test_data/symbol/symbol_test1.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Any\n",
+    "\n",
+    "from . import somemodule, somemodule2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOME_CONSTANT = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def do_work():\n",
+    "    \"\"\"Function for symbols test.\"\"\"\n",
+    "    somemodule.do_something()\n",
+    "    somemodule2.do_something_else()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SomeClass:\n",
+    "    \"\"\"Class for symbols test.\"\"\"\n",
+    "\n",
+    "    def __init__(self, arg1: Any):\n",
+    "        self.somedata = arg1\n",
+    "\n",
+    "    def do_something(self):\n",
+    "        \"\"\"Method for symbols test.\"\"\"\n",
+    "\n",
+    "    def so_something_else(self):\n",
+    "        \"\"\"Method for symbols test.\"\"\""
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Fixes #324.

### Overview

1. Identify when a `textDocument/*` request is for a notebook cell.
2. Use the concatenated notebook source instead of just the individual cell.
3. Change any input positions and ranges to be relative to the concatenated notebook instead of the individual cell.
4. Finally, change any output positions and ranges to be relative to individual cells instead of the concatenated notebook.

### Unchanged language features

The following methods are excluded because the full notebook source shouldn't affect the result of a given cell:

1. `textDocument/documentSymbol`
2. `textDocument/highlight`

### Unsupported cases

There are also a few methods which work well if the source of the request is from a notebook cell, but ignore any _other_ `.ipynb` files. I think the root of this issue is that Jedi doesn't support `.ipynb` files:

1. `textDocument/references`
2. `textDocument/rename`
4. `workspace/symbol`

### Questions
